### PR TITLE
Add unit tests for float codec, client read/write, and CLI tools

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+"""Smoke tests for command line interfaces."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_client_cli_runs() -> None:
+    subprocess.run([sys.executable, str(ROOT / "client.py"), "--help"], check=True)
+
+
+def test_codec_cli_runs() -> None:
+    subprocess.run([sys.executable, str(ROOT / "codec.py"), "--help"], check=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,26 +10,46 @@ import time
 # Ensure project root on path
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from pymodbus.datastore import ModbusSequentialDataBlock, ModbusDeviceContext, ModbusServerContext
+from pymodbus.datastore import (
+    ModbusDeviceContext,
+    ModbusServerContext,
+    ModbusSequentialDataBlock,
+)
 from pymodbus.server import StartTcpServer
 
 from client import VSensorClient
 
 
-def _run_server() -> None:
-    block = ModbusSequentialDataBlock(1, [25, 50])
+def _run_server(port: int, initial: list[int]) -> None:
+    """Run a simple Modbus TCP server for testing."""
+
+    block = ModbusSequentialDataBlock(1, initial)
     device = ModbusDeviceContext(hr=block)
     context = ModbusServerContext(device, single=True)
-    StartTcpServer(context, address=("127.0.0.1", 5020))
+    StartTcpServer(context, address=("127.0.0.1", port))
+
+
+def _start_server(port: int, initial: list[int]) -> None:
+    thread = threading.Thread(target=_run_server, args=(port, initial), daemon=True)
+    thread.start()
+    time.sleep(0.2)
 
 
 def test_read_registers() -> None:
-    thread = threading.Thread(target=_run_server, daemon=True)
-    thread.start()
-    time.sleep(0.2)
+    _start_server(5020, [25, 50])
 
     client = VSensorClient(method="tcp", host="127.0.0.1", tcp_port=5020)
     assert client.connect()
     assert client.read_register(0) == 25
     assert client.read_register(1) == 50
+    client.close()
+
+
+def test_write_registers() -> None:
+    _start_server(5021, [0, 0])
+
+    client = VSensorClient(method="tcp", host="127.0.0.1", tcp_port=5021)
+    assert client.connect()
+    assert client.write_register(0, 123)
+    assert client.read_register(0) == 123
     client.close()

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,30 @@
+"""Tests for float encoding/decoding helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+import codec
+from codec import FloatFormat, decode_float32, set_default_float_format
+
+
+@pytest.mark.parametrize(
+    "fmt, registers",
+    [
+        (FloatFormat.FORMAT_1, [0xA470, 0x9D3F]),
+        (FloatFormat.FORMAT_2, [0x70A4, 0x3F9D]),
+        (FloatFormat.FORMAT_3, [0x3F9D, 0x70A4]),
+        (FloatFormat.FORMAT_4, [0x9D3F, 0xA470]),
+    ],
+)
+def test_decode_float32_all_formats(fmt: FloatFormat, registers: list[int]) -> None:
+    assert decode_float32(registers, fmt) == pytest.approx(1.23, rel=1e-6)
+
+
+def test_decode_uses_default_format() -> None:
+    original = codec.DEFAULT_FLOAT_FORMAT
+    try:
+        set_default_float_format(FloatFormat.FORMAT_3)
+        assert decode_float32([0x3F9D, 0x70A4]) == pytest.approx(1.23, rel=1e-6)
+    finally:
+        set_default_float_format(original)


### PR DESCRIPTION
## Summary
- test float32 decoding for all sensor byte/word orders
- cover client read and write operations against a simulated Modbus server
- add smoke tests ensuring CLI scripts execute without errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c290e03f0c8333a13204c32686bca3