### PR TITLE
Add register names and lookup tables for fast access

### DIFF
--- a/client.py
+++ b/client.py
@@ -24,7 +24,7 @@ from pymodbus.client import ModbusSerialClient, ModbusTcpClient
 from pymodbus.exceptions import ModbusException
 
 from codec import decode_float32, encode_float32
-from registers import REGISTERS, zero_based
+from registers import BY_ADDR, BY_NAME, zero_based
 
 LOGGER = logging.getLogger(__name__)
 
@@ -136,15 +136,12 @@ class VSensorClient:
 
         if isinstance(register, str):
             # allow lookup by symbolic name if desired
-            reg_spec = next(
-                (spec for spec in REGISTERS.values() if spec.get("name") == register),
-                None,
-            )
+            reg_spec = BY_NAME.get(register)
             if not reg_spec:
                 raise KeyError(f"Unknown register name: {register}")
             return zero_based(reg_spec["address"]), reg_spec
 
-        reg_spec = REGISTERS.get(register)
+        reg_spec = BY_ADDR.get(register)
         if reg_spec:
             return zero_based(reg_spec["address"]), reg_spec
         # Not part of REGISTERS -> assume caller already used 0-based address

--- a/registers.py
+++ b/registers.py
@@ -27,72 +27,84 @@ def zero_based(address: int) -> int:
 REGISTERS = {
     138: {
         "address": 138,
+        "name": "low_alarm_threshold_deprecated",
         "type": "u16",
         "rw": "RW",
         "description": "Low Alarm Threshold (deprecated, use 216/217)",
     },
     139: {
         "address": 139,
+        "name": "high_alarm_threshold_deprecated",
         "type": "u16",
         "rw": "RW",
         "description": "High Alarm Threshold (deprecated, use 218/219)",
     },
     140: {
         "address": 140,
+        "name": "alarm_timer_1",
         "type": "u16",
         "rw": "RW",
         "description": "Alarm Timer 1 (s or 0.1 h)",
     },
     141: {
         "address": 141,
+        "name": "alarm1_status",
         "type": "u16",
         "rw": "R",
         "description": "Alarm 1 Status (0=OK, 1=Low Alarm)",
     },
     142: {
         "address": 142,
+        "name": "alarm2_status",
         "type": "u16",
         "rw": "R",
         "description": "Alarm 2 Status (0=OK, 1=High Alarm)",
     },
     143: {
         "address": 143,
+        "name": "alarm_timer_2",
         "type": "u16",
         "rw": "RW",
         "description": "Alarm Timer 2",
     },
     144: {
         "address": 144,
+        "name": "alarm_bits",
         "type": "u16",
         "rw": "RW",
         "description": "Alarm Bits: Bit0 Low, Bit1 High, Bit2 Common, Bit3 Unmuted, Bit4 Healthy",
     },
     145: {
         "address": 145,
+        "name": "buzzer_status",
         "type": "u16",
         "rw": "RW",
         "description": "Buzzer Status (1=Unmuted Alarm present)",
     },
     146: {
         "address": 146,
+        "name": "heartbeat",
         "type": "u16",
         "rw": "R",
         "description": "Heartbeat (seconds tick, rolls over at 65535)",
     },
     147: {
         "address": 147,
+        "name": "alarm_mode0_relay",
         "type": "u16",
         "rw": "RW",
         "description": "Alarm Mode 0 Relay (write 1 = energize)",
     },
     148: {
         "address": 148,
+        "name": "alarm_mode0_buzzer",
         "type": "u16",
         "rw": "RW",
         "description": "Alarm Mode 0 Buzzer (write 1 = ON)",
     },
     149: {
         "address": 149,
+        "name": "display_value",
         "type": "float32",
         "length": 2,
         "rw": "R",
@@ -100,6 +112,7 @@ REGISTERS = {
     },
     151: {
         "address": 151,
+        "name": "pascals",
         "type": "float32",
         "length": 2,
         "rw": "R",
@@ -107,6 +120,7 @@ REGISTERS = {
     },
     153: {
         "address": 153,
+        "name": "setpoint",
         "type": "float32",
         "length": 2,
         "rw": "RW",
@@ -114,30 +128,35 @@ REGISTERS = {
     },
     155: {
         "address": 155,
+        "name": "pid_output",
         "type": "s16",
         "rw": "R",
         "description": "PID Output (–4095…+4095)",
     },
     156: {
         "address": 156,
+        "name": "mode",
         "type": "u16",
         "rw": "RW",
         "description": "Mode: 0=Disabled, 1=Auto, 2=Hand, 3=Off, 4=Hand@current",
     },
     158: {
         "address": 158,
+        "name": "pressure",
         "type": "s16",
         "rw": "R",
         "description": "Pressure (int, 0.1 Pa <2500Pa, else 1 Pa)",
     },
     164: {
         "address": 164,
+        "name": "text_display",
         "type": "u16",
         "rw": "RW",
         "description": "Text Display (LED version only, 0=Normal, 1=Error, 2=Fault, 3=Off, 4=Stop; +16 = alternating)",
     },
     165: {
         "address": 165,
+        "name": "hand_setpoint",
         "type": "float32",
         "length": 2,
         "rw": "RW",
@@ -145,6 +164,7 @@ REGISTERS = {
     },
     167: {
         "address": 167,
+        "name": "control_output",
         "type": "float32",
         "length": 2,
         "rw": "R",
@@ -152,6 +172,7 @@ REGISTERS = {
     },
     216: {
         "address": 216,
+        "name": "low_alarm_threshold",
         "type": "float32",
         "length": 2,
         "rw": "RW",
@@ -159,9 +180,14 @@ REGISTERS = {
     },
     218: {
         "address": 218,
+        "name": "high_alarm_threshold",
         "type": "float32",
         "length": 2,
         "rw": "RW",
         "description": "High Alarm Threshold (Display Units)",
     },
 }
+
+BY_ADDR = {spec["address"]: spec for spec in REGISTERS.values()}
+BY_NAME = {spec["name"]: spec for spec in REGISTERS.values()}
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -53,3 +53,13 @@ def test_write_registers() -> None:
     assert client.write_register(0, 123)
     assert client.read_register(0) == 123
     client.close()
+
+
+def test_lookup_by_name() -> None:
+    _start_server(5022, [0] * 300)
+
+    client = VSensorClient(method="tcp", host="127.0.0.1", tcp_port=5022)
+    assert client.connect()
+    assert client.write_register("buzzer_status", 1)
+    assert client.read_register("buzzer_status") == 1
+    client.close()


### PR DESCRIPTION
## Summary
- add unique `name` metadata to each register and expose fast lookup dictionaries `BY_ADDR` and `BY_NAME`
- speed up register lookups by using `BY_NAME` in `VSensorClient._spec_for`
- test name-based register access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29ae043c083338d6dd01d1dd92b70