### PR TITLE
Add VSensorService for background polling

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,21 @@
+"""Common protocol for V-Sensor client implementations."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, Protocol
+
+
+class VSensorAPI(Protocol):
+    """Protocol describing the V-Sensor client/service API."""
+
+    def read_register(self, name: str) -> Optional[int | float]:
+        """Read a single register value."""
+        ...
+
+    def write_register(self, name: str, value: int | float) -> bool:
+        """Write a register value."""
+        ...
+
+    def read_all(self, registers: Iterable[str] | None = None) -> Dict[str, Optional[int | float]]:
+        """Read multiple registers at once."""
+        ...

--- a/client.py
+++ b/client.py
@@ -187,6 +187,19 @@ class VSensorClient:
             return _to_signed(regs[0])
         return regs[0]
 
+    def read_all(self, registers: Optional[Iterable[str]] = None) -> dict[str, Optional[int | float]]:
+        """Read multiple registers at once.
+
+        Parameters
+        ----------
+        registers:
+            Optional iterable of register names. When omitted all registers in
+            :data:`registers.BY_NAME` are used.
+        """
+
+        names = list(registers) if registers is not None else list(BY_NAME.keys())
+        return {name: self.read_register(name) for name in names}
+
     def write_register(self, register: int | str, value: int | float) -> bool:
         """Write a register on the sensor.
 

--- a/service.py
+++ b/service.py
@@ -1,0 +1,164 @@
+"""Background service for polling V-Sensor registers."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional
+
+from client import VSensorClient
+from registers import BY_NAME
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Quality(Enum):
+    """Quality indicator for cached register values."""
+
+    OK = "OK"
+    STALE = "STALE"
+    ERROR = "ERROR"
+
+
+class VSensorService:
+    """Poll registers from a :class:`VSensorClient` in the background."""
+
+    def __init__(
+        self,
+        *,
+        registers: Optional[Iterable[str]] = None,
+        interval: float = 5.0,
+        stale_after: float | None = None,
+        client: Optional[VSensorClient] = None,
+        **client_kwargs: Any,
+    ) -> None:
+        """Create the service and start the polling thread.
+
+        Parameters
+        ----------
+        registers:
+            Iterable of register names to poll. If ``None`` all registers in
+            :data:`registers.BY_NAME` are used.
+        interval:
+            Polling interval in seconds.
+        stale_after:
+            Age in seconds after which a value is considered stale. Defaults to
+            ``2 * interval`` when ``None``.
+        client:
+            Optional :class:`VSensorClient` instance. When omitted a new client is
+            created using ``client_kwargs`` and :meth:`VSensorClient.connect` is
+            called.
+        client_kwargs:
+            Additional keyword arguments forwarded to :class:`VSensorClient` when
+            ``client`` is ``None``.
+        """
+
+        if registers is None:
+            self._registers = list(BY_NAME.keys())
+        else:
+            for name in registers:
+                if name not in BY_NAME:
+                    raise KeyError(f"Unknown register: {name}")
+            self._registers = list(registers)
+
+        self._interval = interval
+        self._stale_after = stale_after if stale_after is not None else interval * 2
+
+        self._client = client or VSensorClient(**client_kwargs)
+        if client is None:
+            try:
+                self._client.connect()
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.error("Failed to connect: %s", exc)
+
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self._running = True
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    def _poll_loop(self) -> None:
+        while self._running:
+            for name in self._registers:
+                try:
+                    value = self._client.read_register(name)
+                except Exception as exc:  # pragma: no cover - defensive
+                    LOGGER.error("Polling %s failed: %s", name, exc)
+                    value = None
+                quality = Quality.OK if value is not None else Quality.ERROR
+                with self._lock:
+                    self._cache[name] = {
+                        "value": value,
+                        "timestamp": time.time(),
+                        "quality": quality,
+                    }
+            time.sleep(self._interval)
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Stop the background thread and close the client."""
+        self._running = False
+        self._thread.join(timeout=self._interval)
+        try:
+            self._client.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    close = stop  # alias
+
+    # ------------------------------------------------------------------
+    def _apply_stale(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        if time.time() - entry["timestamp"] > self._stale_after:
+            entry = dict(entry)
+            entry["quality"] = Quality.STALE
+        return entry
+
+    def read_register(self, name: str) -> Optional[int | float]:
+        """Return the cached value for ``name``."""
+        with self._lock:
+            entry = self._cache.get(name)
+        if entry is None:
+            return None
+        entry = self._apply_stale(entry)
+        if entry["quality"] is Quality.ERROR:
+            return None
+        return entry["value"]
+
+    def read_all(self) -> Dict[str, Optional[int | float]]:
+        """Return cached values for all registers."""
+        with self._lock:
+            items = {k: dict(v) for k, v in self._cache.items()}
+        result: Dict[str, Optional[int | float]] = {}
+        for name, entry in items.items():
+            entry = self._apply_stale(entry)
+            result[name] = None if entry["quality"] is Quality.ERROR else entry["value"]
+        return result
+
+    def write_register(self, name: str, value: int | float) -> bool:
+        """Write a register and update the cache on success."""
+        try:
+            ok = self._client.write_register(name, value)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.error("Write %s failed: %s", name, exc)
+            ok = False
+        if ok:
+            with self._lock:
+                self._cache[name] = {
+                    "value": value,
+                    "timestamp": time.time(),
+                    "quality": Quality.OK,
+                }
+        return ok
+
+    # ------------------------------------------------------------------
+    def status(self, name: str) -> Optional[Quality]:
+        """Return the :class:`Quality` for ``name``."""
+        with self._lock:
+            entry = self._cache.get(name)
+        if entry is None:
+            return None
+        entry = self._apply_stale(entry)
+        return entry["quality"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,96 @@
+"""Tests for the VSensorService."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+from typing import Any, Dict
+
+# Ensure project root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from service import Quality, VSensorService
+
+
+class FakeClient:
+    """Simple stand-in for :class:`VSensorClient` used in tests."""
+
+    def __init__(self, values: Dict[str, Any], errors: set[str] | None = None) -> None:
+        self.values = values
+        self.errors = errors or set()
+        self.writes: list[tuple[str, Any]] = []
+
+    def connect(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def read_register(self, name: str) -> Any:
+        if name in self.errors:
+            return None
+        return self.values.get(name)
+
+    def write_register(self, name: str, value: Any) -> bool:
+        self.values[name] = value
+        self.writes.append((name, value))
+        return True
+
+
+def test_poll_and_read() -> None:
+    client = FakeClient({"heartbeat": 5})
+    service = VSensorService(
+        client=client, registers=["heartbeat"], interval=0.05, stale_after=0.2
+    )
+    time.sleep(0.1)
+    assert service.read_register("heartbeat") == 5
+    assert service.status("heartbeat") is Quality.OK
+    service.stop()
+
+
+def test_stale_detection() -> None:
+    client = FakeClient({"heartbeat": 1})
+    service = VSensorService(
+        client=client, registers=["heartbeat"], interval=0.05, stale_after=0.1
+    )
+    time.sleep(0.1)
+    service.stop()
+    time.sleep(0.15)
+    assert service.status("heartbeat") is Quality.STALE
+
+
+def test_error_quality() -> None:
+    client = FakeClient({}, errors={"heartbeat"})
+    service = VSensorService(
+        client=client, registers=["heartbeat"], interval=0.05, stale_after=0.2
+    )
+    time.sleep(0.1)
+    assert service.read_register("heartbeat") is None
+    assert service.status("heartbeat") is Quality.ERROR
+    service.stop()
+
+
+def test_write_updates_cache() -> None:
+    client = FakeClient({"heartbeat": 1})
+    service = VSensorService(
+        client=client, registers=["heartbeat"], interval=0.05, stale_after=0.2
+    )
+    time.sleep(0.1)
+    assert service.write_register("heartbeat", 2)
+    time.sleep(0.1)
+    assert service.read_register("heartbeat") == 2
+    service.stop()
+
+
+def test_read_all() -> None:
+    client = FakeClient({"heartbeat": 5, "mode": 3})
+    service = VSensorService(
+        client=client, registers=["heartbeat", "mode"], interval=0.05, stale_after=0.2
+    )
+    time.sleep(0.1)
+    data = service.read_all()
+    assert set(data) == {"heartbeat", "mode"}
+    assert data["heartbeat"] == 5
+    assert service.status("heartbeat") is Quality.OK
+    service.stop()


### PR DESCRIPTION
## Summary
- align `VSensorService` API with `VSensorClient` using `read_register`, `read_all`, and `write_register`
- expose `status` helper and formalize shared interface in `api.VSensorAPI`
- implement `VSensorClient.read_all` and update service tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29c39ee448333b9373b24a4150e39