### PR TITLE
Refactor VSensor service API and GUI configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "MIT"}
 dependencies = [
     "pymodbus",
     "fastapi",
+    "platformdirs",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- Ensure VSensorService spawns only one polling thread and joins it on stop
- Expose `get_entry`/`get_all_entries` with stale evaluation for GUI use
- Move GUI config to user path via platformdirs, add migration, and apply per-card formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b7120e18833381c3a782ec50f6ae