### PR TITLE
Add FastAPI health endpoints and runnable vsensor API

### DIFF
--- a/apps/headless_service.py
+++ b/apps/headless_service.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import os
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
 from service import VSensorService
 
+HOST = os.getenv("HOST", "127.0.0.1")
+PORT = int(os.getenv("PORT", "8000"))
+INTERVAL = float(os.getenv("INTERVAL", "5.0"))
+_stale_after = os.getenv("STALE_AFTER")
+STALE_AFTER = float(_stale_after) if _stale_after is not None else None
+
 app = FastAPI(title="VSensor Headless Service")
-service = VSensorService(interval=5.0)
+service = VSensorService(interval=INTERVAL, stale_after=STALE_AFTER)
 
 
 class RegisterValue(BaseModel):
@@ -39,7 +47,39 @@ def write_register(name: str, payload: RegisterValue) -> RegisterValue:
     return RegisterValue(value=payload.value)
 
 
+@app.get("/healthz")
+def healthz() -> dict[str, int | float | bool | None]:
+    """Return service health and statistics."""
+    return {
+        "connected": service.last_poll_ok(),
+        "last_success_ts": service.last_success_ts,
+        "poll_interval": service.poll_interval,
+        "stale_after": service.stale_after,
+        "polls_total": service.polls_total,
+        "errors_total": service.errors_total,
+        "uptime": service.uptime,
+    }
+
+
+@app.get("/metrics")
+def metrics() -> PlainTextResponse:
+    """Return metrics in a simple text format."""
+    data = healthz()
+    lines = [f"{k} {v}" for k, v in data.items()]
+    return PlainTextResponse("\n".join(lines))
+
+
 @app.on_event("shutdown")
 def shutdown() -> None:
     """Stop background polling when the service shuts down."""
     service.stop()
+
+
+def main() -> None:
+    """Run the API using ``uvicorn``."""
+    import uvicorn
+
+    try:
+        uvicorn.run(app, host=HOST, port=PORT)
+    finally:
+        service.stop()

--- a/client.py
+++ b/client.py
@@ -73,9 +73,14 @@ class VSensorClient:
         """
 
         if method == "rtu":
-            self._client = ModbusSerialClient(
-                method="rtu", port=port, baudrate=baudrate, timeout=timeout
-            )
+            try:
+                self._client = ModbusSerialClient(
+                    method="rtu", port=port, baudrate=baudrate, timeout=timeout
+                )
+            except TypeError:  # pragma: no cover - compatibility
+                self._client = ModbusSerialClient(
+                    port=port, baudrate=baudrate, timeout=timeout
+                )
         elif method == "tcp":
             self._client = ModbusTcpClient(host=host, port=tcp_port, timeout=timeout)
         else:  # pragma: no cover - defensive programming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,17 @@ build-backend = "setuptools.build_meta"
 name = "pymodbus-vsensor"
 version = "0.1.0"
 description = "Communication with CMR Controls V-Sensor over Modbus"
-authors = [{name = "", email = ""}]
+authors = [{name = "", email = "dev@example.com"}]
 readme = "README.md"
 license = {text = "MIT"}
 dependencies = [
     "pymodbus",
     "fastapi",
+    "uvicorn[standard]",
 ]
+
+[project.scripts]
+vsensor-api = "apps.headless_service:main"
 
 [tool.pytest.ini_options]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- expose `/healthz` and `/metrics` endpoints with polling statistics
- add counters and uptime tracking to `VSensorService`
- provide `vsensor-api` console command to launch FastAPI app with uvicorn
- ensure Modbus client works with new pymodbus versions

## Testing
- `pytest`
- `PYTHONPATH=/workspace/pyModbus_V-Sensor INTERVAL=0.2 vsensor-api` (manual run; checked `/healthz` and `/metrics`)


------
https://chatgpt.com/codex/tasks/task_e_68c2b802ff988333820b09fdd83255af