### PR TITLE
Refine VSensorService API and GUI configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pymodbus",
     "fastapi",
     "uvicorn[standard]",
+    "platformdirs",
 ]
 
 [project.scripts]

--- a/registers.py
+++ b/registers.py
@@ -109,6 +109,8 @@ REGISTERS = {
         "length": 2,
         "rw": "R",
         "description": "Display Value (as shown on display)",
+        "format": "{:.2f}",
+        "unit": "",
     },
     151: {
         "address": 151,
@@ -117,6 +119,8 @@ REGISTERS = {
         "length": 2,
         "rw": "R",
         "description": "Pascals (measured pressure)",
+        "format": "{:.1f}",
+        "unit": "Pa",
     },
     153: {
         "address": 153,
@@ -125,6 +129,8 @@ REGISTERS = {
         "length": 2,
         "rw": "RW",
         "description": "Control/PID Setpoint",
+        "format": "{:.1f}",
+        "unit": "Pa",
     },
     155: {
         "address": 155,
@@ -132,6 +138,8 @@ REGISTERS = {
         "type": "s16",
         "rw": "R",
         "description": "PID Output (–4095…+4095)",
+        "format": "{:.0f}",
+        "unit": "",
     },
     156: {
         "address": 156,
@@ -146,6 +154,8 @@ REGISTERS = {
         "type": "s16",
         "rw": "R",
         "description": "Pressure (int, 0.1 Pa <2500Pa, else 1 Pa)",
+        "format": "{:.1f}",
+        "unit": "Pa",
     },
     164: {
         "address": 164,
@@ -161,6 +171,8 @@ REGISTERS = {
         "length": 2,
         "rw": "RW",
         "description": "Hand Setpoint (%)",
+        "format": "{:.1f}",
+        "unit": "%",
     },
     167: {
         "address": 167,
@@ -169,6 +181,8 @@ REGISTERS = {
         "length": 2,
         "rw": "R",
         "description": "Control Output (%)",
+        "format": "{:.1f}",
+        "unit": "%",
     },
     216: {
         "address": 216,
@@ -177,6 +191,8 @@ REGISTERS = {
         "length": 2,
         "rw": "RW",
         "description": "Low Alarm Threshold (Display Units)",
+        "format": "{:.1f}",
+        "unit": "",
     },
     218: {
         "address": 218,
@@ -185,6 +201,8 @@ REGISTERS = {
         "length": 2,
         "rw": "RW",
         "description": "High Alarm Threshold (Display Units)",
+        "format": "{:.1f}",
+        "unit": "",
     },
 }
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -94,3 +94,22 @@ def test_read_all() -> None:
     assert data["heartbeat"] == 5
     assert service.status("heartbeat") is Quality.OK
     service.stop()
+
+
+def test_get_entry_api() -> None:
+    client = FakeClient({"heartbeat": 5})
+    service = VSensorService(
+        client=client, registers=["heartbeat"], interval=0.05, stale_after=0.1
+    )
+    time.sleep(0.1)
+    entry = service.get_entry("heartbeat")
+    assert entry is not None
+    assert entry["value"] == 5
+    all_entries = service.get_all_entries()
+    assert "heartbeat" in all_entries
+    assert all_entries["heartbeat"]["quality"] is Quality.OK
+    service.stop()
+    time.sleep(0.15)
+    entry = service.get_entry("heartbeat")
+    assert entry is not None
+    assert entry["quality"] is Quality.STALE


### PR DESCRIPTION
## Summary
- prevent VSensorService from spawning duplicate polling threads and expose cache via `get_entry` and `get_all_entries`
- migrate GUI configuration to a user-specific location and rely on public service API with formatted register values
- add formatting metadata to register spec and expose new service tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2bc5c4c388333b3a39e676a706af6