### PR TITLE
Add GUI connection settings dialog

### DIFF
--- a/apps/gui_app.py
+++ b/apps/gui_app.py
@@ -15,6 +15,17 @@ CONFIG_FILE_OLD = Path(__file__).with_name("gui_app_config.json")
 CONFIG_FILE = user_config_path("vsensor") / "gui.json"
 DEFAULT_REGISTERS: list[str] = []  # explicit start list
 DEFAULT_INTERVAL = 0.5
+DEFAULT_CLIENT_CONFIG: dict[str, object] = {
+    "method": "rtu",
+    "port": "/dev/ttyUSB0",
+    "baudrate": 9600,
+    "parity": "N",
+    "stopbits": 1,
+    "host": "localhost",
+    "tcp_port": 502,
+    "device_id": 1,
+    "timeout": 3.0,
+}
 
 
 class DashboardApp:
@@ -30,7 +41,15 @@ class DashboardApp:
         self.poll_interval = self.config.get("poll_interval", DEFAULT_INTERVAL)
         self.update_interval = int(self.poll_interval * 1000)
 
-        self.service = VSensorService(registers=self.selected, interval=self.poll_interval)
+        connection_cfg = self.config.get("connection", {})
+        if not isinstance(connection_cfg, dict):
+            connection_cfg = {}
+        self.client_config: dict[str, object] = dict(DEFAULT_CLIENT_CONFIG)
+        self.client_config.update(connection_cfg)
+
+        self.service = VSensorService(
+            registers=self.selected, interval=self.poll_interval, **self.client_config
+        )
 
         self.banner_var = tk.StringVar(value="")
         self.banner = tk.Label(self.root, textvariable=self.banner_var, bg="red", fg="white")
@@ -51,6 +70,7 @@ class DashboardApp:
         settings = tk.Menu(menubar, tearoff=False)
         settings.add_command(label="Select Registers", command=self.select_registers)
         settings.add_command(label="Poll Interval", command=self.change_interval)
+        settings.add_command(label="Connection…", command=self.configure_connection)
         menubar.add_cascade(label="Settings", menu=settings)
         self.root.config(menu=menubar)
 
@@ -76,7 +96,11 @@ class DashboardApp:
         return {}
 
     def save_config(self) -> None:
-        data = {"registers": self.selected, "poll_interval": self.poll_interval}
+        data = {
+            "registers": self.selected,
+            "poll_interval": self.poll_interval,
+            "connection": self.client_config,
+        }
         try:
             CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
             with open(CONFIG_FILE, "w", encoding="utf-8") as fh:
@@ -237,6 +261,173 @@ class DashboardApp:
             return
         if not self.service.write_register(name, value):
             messagebox.showerror("Error", "Write failed")
+
+    # ------------------------------------------------------------------
+    def configure_connection(self) -> None:
+        top = tk.Toplevel(self.root)
+        top.title("Connection Settings")
+        top.transient(self.root)
+        top.grab_set()
+        top.resizable(False, False)
+
+        method_var = tk.StringVar(value=str(self.client_config.get("method", "rtu")))
+        port_var = tk.StringVar(value=str(self.client_config.get("port", "")))
+        baudrate_var = tk.StringVar(value=str(self.client_config.get("baudrate", "")))
+        parity_var = tk.StringVar(value=str(self.client_config.get("parity", "N")))
+        stopbits_var = tk.StringVar(value=str(self.client_config.get("stopbits", 1)))
+        host_var = tk.StringVar(value=str(self.client_config.get("host", "")))
+        tcp_port_var = tk.StringVar(value=str(self.client_config.get("tcp_port", "")))
+        device_id_var = tk.StringVar(value=str(self.client_config.get("device_id", "")))
+        timeout_var = tk.StringVar(value=str(self.client_config.get("timeout", "")))
+
+        body = tk.Frame(top)
+        body.pack(fill="both", expand=True, padx=10, pady=10)
+        body.columnconfigure(1, weight=1)
+
+        tk.Label(body, text="Method:").grid(row=0, column=0, sticky="w")
+        method_menu = tk.OptionMenu(body, method_var, "rtu", "tcp")
+        method_menu.grid(row=0, column=1, sticky="ew")
+
+        rtu_frame = tk.LabelFrame(body, text="Serial (RTU)")
+        rtu_opts = {"row": 1, "column": 0, "columnspan": 2, "sticky": "ew", "pady": (10, 0)}
+        rtu_frame.grid(**rtu_opts)
+        rtu_frame.columnconfigure(1, weight=1)
+
+        tk.Label(rtu_frame, text="Port:").grid(row=0, column=0, sticky="w")
+        tk.Entry(rtu_frame, textvariable=port_var).grid(row=0, column=1, sticky="ew")
+        tk.Label(rtu_frame, text="Baudrate:").grid(row=1, column=0, sticky="w")
+        tk.Entry(rtu_frame, textvariable=baudrate_var).grid(row=1, column=1, sticky="ew")
+        tk.Label(rtu_frame, text="Parity:").grid(row=2, column=0, sticky="w")
+        parity_menu = tk.OptionMenu(rtu_frame, parity_var, "N", "E", "O")
+        parity_menu.grid(row=2, column=1, sticky="ew")
+        tk.Label(rtu_frame, text="Stopbits:").grid(row=3, column=0, sticky="w")
+        stopbits_menu = tk.OptionMenu(rtu_frame, stopbits_var, "1", "2")
+        stopbits_menu.grid(row=3, column=1, sticky="ew")
+
+        tcp_frame = tk.LabelFrame(body, text="TCP")
+        tcp_opts = {"row": 2, "column": 0, "columnspan": 2, "sticky": "ew", "pady": (10, 0)}
+        tcp_frame.grid(**tcp_opts)
+        tcp_frame.columnconfigure(1, weight=1)
+
+        tk.Label(tcp_frame, text="Host:").grid(row=0, column=0, sticky="w")
+        tk.Entry(tcp_frame, textvariable=host_var).grid(row=0, column=1, sticky="ew")
+        tk.Label(tcp_frame, text="Port:").grid(row=1, column=0, sticky="w")
+        tk.Entry(tcp_frame, textvariable=tcp_port_var).grid(row=1, column=1, sticky="ew")
+
+        general_frame = tk.LabelFrame(body, text="General")
+        general_frame.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+        general_frame.columnconfigure(1, weight=1)
+
+        tk.Label(general_frame, text="Device ID:").grid(row=0, column=0, sticky="w")
+        tk.Entry(general_frame, textvariable=device_id_var).grid(row=0, column=1, sticky="ew")
+        tk.Label(general_frame, text="Timeout (s):").grid(row=1, column=0, sticky="w")
+        tk.Entry(general_frame, textvariable=timeout_var).grid(row=1, column=1, sticky="ew")
+
+        def update_frames(*_args: object) -> None:
+            if method_var.get() == "rtu":
+                rtu_frame.grid(**rtu_opts)
+                tcp_frame.grid_remove()
+            else:
+                tcp_frame.grid(**tcp_opts)
+                rtu_frame.grid_remove()
+
+        method_var.trace_add("write", update_frames)
+        update_frames()
+
+        def apply() -> None:
+            new_config = dict(DEFAULT_CLIENT_CONFIG)
+            new_config.update(self.client_config)
+
+            method = method_var.get()
+            new_config["method"] = method
+
+            port = port_var.get().strip()
+            if port:
+                new_config["port"] = port
+            elif method == "rtu":
+                messagebox.showerror("Invalid", "Port must not be empty for RTU")
+                return
+
+            baudrate_str = baudrate_var.get().strip()
+            if baudrate_str:
+                try:
+                    baudrate = int(baudrate_str)
+                    if baudrate <= 0:
+                        raise ValueError
+                except ValueError:
+                    messagebox.showerror("Invalid", "Baudrate must be a positive integer")
+                    return
+                new_config["baudrate"] = baudrate
+            elif method == "rtu":
+                messagebox.showerror("Invalid", "Baudrate must be provided for RTU")
+                return
+
+            parity = parity_var.get()
+            new_config["parity"] = parity
+
+            try:
+                stopbits = int(stopbits_var.get())
+            except ValueError:
+                messagebox.showerror("Invalid", "Stopbits must be 1 or 2")
+                return
+            if stopbits not in {1, 2}:
+                messagebox.showerror("Invalid", "Stopbits must be 1 or 2")
+                return
+            new_config["stopbits"] = stopbits
+
+            host = host_var.get().strip()
+            if host:
+                new_config["host"] = host
+            elif method == "tcp":
+                messagebox.showerror("Invalid", "Host must not be empty for TCP")
+                return
+
+            tcp_port_str = tcp_port_var.get().strip()
+            if tcp_port_str:
+                try:
+                    tcp_port = int(tcp_port_str)
+                    if tcp_port <= 0:
+                        raise ValueError
+                except ValueError:
+                    messagebox.showerror("Invalid", "TCP port must be a positive integer")
+                    return
+                new_config["tcp_port"] = tcp_port
+            elif method == "tcp":
+                messagebox.showerror("Invalid", "TCP port must be provided for TCP")
+                return
+
+            device_id_str = device_id_var.get().strip()
+            try:
+                device_id = int(device_id_str)
+                if device_id <= 0:
+                    raise ValueError
+            except ValueError:
+                messagebox.showerror("Invalid", "Device ID must be a positive integer")
+                return
+            new_config["device_id"] = device_id
+
+            timeout_str = timeout_var.get().strip()
+            try:
+                timeout = float(timeout_str)
+                if timeout <= 0:
+                    raise ValueError
+            except ValueError:
+                messagebox.showerror("Invalid", "Timeout must be a positive number")
+                return
+            new_config["timeout"] = timeout
+
+            self.service.stop()
+            self.service.configure(**new_config)
+            self.service.start()
+            self.client_config = new_config
+            self.save_config()
+            self.schedule_update()
+            top.destroy()
+
+        btn_frame = tk.Frame(top)
+        btn_frame.pack(fill="x", padx=10, pady=(0, 10))
+        tk.Button(btn_frame, text="Cancel", command=top.destroy).pack(side=tk.RIGHT)
+        tk.Button(btn_frame, text="Apply", command=apply).pack(side=tk.RIGHT, padx=(0, 5))
 
     # ------------------------------------------------------------------
     def on_close(self) -> None:


### PR DESCRIPTION
## Summary
- add persisted default Modbus client configuration for the dashboard
- add a connection settings dialog that validates input and reconfigures the service
- save the selected connection options alongside existing GUI preferences

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d398d3881483338960df0d67861395